### PR TITLE
Fixes #12, removed unset and unneeded global variable

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -103,6 +103,5 @@ elif [[ $TEST_SUITE == "integration" ]]; then
 	go get github.com/smartystreets/goconvey/convey
 	go get github.com/smartystreets/assertions
 	
-	cd $SNAP_PLUGIN_SOURCE
 	SNAP_CASSANDRA_HOST=127.0.0.1 go test -v --tags=integration ./...
 fi


### PR DESCRIPTION
Removed unset and unneeded global variable, unset variable moves tests to wrong localization. Now `make check TEST=integration` works correctly.
