### PR TITLE
we should save timestamp from metric rather then timestamp of insertion

### DIFF
--- a/cassandra/cassandra.go
+++ b/cassandra/cassandra.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	name       = "cassandra"
-	version    = 4
+	version    = 5
 	pluginType = plugin.PublisherPluginType
 
 	serverAddrRuleKey          = "server"

--- a/cassandra/client.go
+++ b/cassandra/client.go
@@ -118,7 +118,7 @@ func worker(s *gocql.Session, m plugin.MetricType) error {
 			m.Namespace().String(),
 			m.Version(),
 			m.Tags()[core.STD_TAG_PLUGIN_RUNNING_ON],
-			time.Now(),
+			m.Timestamp(),
 			"doubleval",
 			value,
 			m.Tags()).Exec(); err != nil {
@@ -132,7 +132,7 @@ func worker(s *gocql.Session, m plugin.MetricType) error {
 			m.Namespace().String(),
 			m.Version(),
 			m.Tags()[core.STD_TAG_PLUGIN_RUNNING_ON],
-			time.Now(),
+			m.Timestamp(),
 			"strval",
 			value,
 			m.Tags()).Exec(); err != nil {
@@ -146,7 +146,7 @@ func worker(s *gocql.Session, m plugin.MetricType) error {
 			m.Namespace().String(),
 			m.Version(),
 			m.Tags()[core.STD_TAG_PLUGIN_RUNNING_ON],
-			time.Now(),
+			m.Timestamp(),
 			"boolval",
 			value,
 			m.Tags()).Exec(); err != nil {


### PR DESCRIPTION
Fixes #19 

Summary of changes:
- saving metric timestamp instead of current timestamp to the database

How to verify it:
- see description of #19 

Testing done:
- all the existing tests are expected to pass.

