### PR TITLE
Increase number of connectivity options

### DIFF
--- a/cassandra/cassandra_integration_test.go
+++ b/cassandra/cassandra_integration_test.go
@@ -35,11 +35,19 @@ import (
 )
 
 const (
+	connectionTimeout            = 2
+	shouldCreateKeyspace         = true
+	enableServerCertVerification = false
+	ignorePeerAddr               = false
+	initialHostLookup            = true
+	keyspaceName                 = "snap"
+	tableName                    = "foo"
+	password                     = "password"
+	port                         = 9042
 	serverAddress                = "127.0.0.1"
 	sslOptionsFlag               = true
+	timeout                      = 2
 	username                     = "username"
-	password                     = "password"
-	enableServerCertVerification = false
 )
 
 func TestCassandraPublish(t *testing.T) {
@@ -54,9 +62,17 @@ func TestCassandraPublish(t *testing.T) {
 			log.Fatal("SNAP_CASSANDRA_HOST is not set")
 		}
 
+		config[connectionTimeoutRuleKey] = ctypes.ConfigValueInt{Value: connectionTimeout}
+		config[createKeyspaceRuleKey] = ctypes.ConfigValueBool{Value: shouldCreateKeyspace}
+		config[ignorePeerAddrRuleKey] = ctypes.ConfigValueBool{Value: ignorePeerAddr}
+		config[initialHostLookupRuleKey] = ctypes.ConfigValueBool{Value: initialHostLookup}
+		config[keyspaceNameRuleKey] = ctypes.ConfigValueStr{Value: keyspaceName}
+		config[portRuleKey] = ctypes.ConfigValueInt{Value: port}
 		config[serverAddrRuleKey] = ctypes.ConfigValueStr{Value: hostip}
 		config[sslOptionsRuleKey] = ctypes.ConfigValueBool{Value: false}
 		config[tagIndexRuleKey] = ctypes.ConfigValueStr{Value: "experimentId,mode,year"}
+		config[timeoutRuleKey] = ctypes.ConfigValueInt{Value: timeout}
+		config[tableNameRuleKey] = ctypes.ConfigValueStr{Value: tableName}
 
 		Convey("Publish integer metric", func() {
 			tags := map[string]string{core.STD_TAG_PLUGIN_RUNNING_ON: "hostname", "experimentId": "101"}

--- a/cassandra/cassandra_test.go
+++ b/cassandra/cassandra_test.go
@@ -31,12 +31,14 @@ import (
 )
 
 const (
-	serverAddress                = "127.0.0.1"
-	sslOptionsFlag               = true
-	username                     = "username"
+	enableServerCertVerification = false
+	keyspaceName                 = "snap"
 	password                     = "password"
 	path                         = "/some/path"
-	enableServerCertVerification = false
+	serverAddress                = "127.0.0.1"
+	sslOptionsFlag               = true
+	tableName                    = "metrics"
+	username                     = "username"
 )
 
 func TestCassandraDBPlugin(t *testing.T) {
@@ -125,14 +127,16 @@ func TestSslOptions(t *testing.T) {
 
 		// Prepare test config with ssl options.
 		testConfig := make(map[string]ctypes.ConfigValue)
-		testConfig[serverAddrRuleKey] = ctypes.ConfigValueStr{Value: serverAddress}
-		testConfig[sslOptionsRuleKey] = ctypes.ConfigValueBool{Value: sslOptionsFlag}
-		testConfig[usernameRuleKey] = ctypes.ConfigValueStr{Value: username}
-		testConfig[passwordRuleKey] = ctypes.ConfigValueStr{Value: password}
 		testConfig[caPathRuleKey] = ctypes.ConfigValueStr{Value: path}
 		testConfig[certPathRuleKey] = ctypes.ConfigValueStr{Value: path}
-		testConfig[keyPathRuleKey] = ctypes.ConfigValueStr{Value: path}
 		testConfig[enableServerCertVerRuleKey] = ctypes.ConfigValueBool{Value: enableServerCertVerification}
+		testConfig[keyPathRuleKey] = ctypes.ConfigValueStr{Value: path}
+		testConfig[keyspaceName] = ctypes.ConfigValueStr{Value: keyspaceName}
+		testConfig[passwordRuleKey] = ctypes.ConfigValueStr{Value: password}
+		testConfig[serverAddrRuleKey] = ctypes.ConfigValueStr{Value: serverAddress}
+		testConfig[sslOptionsRuleKey] = ctypes.ConfigValueBool{Value: sslOptionsFlag}
+		testConfig[tableNameRuleKey] = ctypes.ConfigValueStr{Value: tableName}
+		testConfig[usernameRuleKey] = ctypes.ConfigValueStr{Value: username}
 
 		cfg, errs := configPolicy.Get([]string{""}).Process(testConfig)
 		Convey("So config policy should return a config after processing testConfig with valid ssl options", func() {
@@ -147,9 +151,10 @@ func TestSslOptions(t *testing.T) {
 		Convey("So received ssl options struct should have proper values for all keys", func() {
 			So(reflect.DeepEqual(expectedSslOptions, receivedSslOptions), ShouldBeTrue)
 		})
+		config := prepareClientOptions(testConfig)
 
 		// Prepare cluster for a given address.
-		cluster := createCluster(serverAddress)
+		cluster := createCluster(config)
 		Convey("So while creating cluster it should not be nil", func() {
 			So(cluster, ShouldNotBeNil)
 		})
@@ -168,14 +173,16 @@ func TestSslOptions(t *testing.T) {
 
 		// Prepare test config with invalid ssl options.
 		testConfig = make(map[string]ctypes.ConfigValue)
+		testConfig[caPathRuleKey] = ctypes.ConfigValueInt{Value: 0}
+		testConfig[certPathRuleKey] = ctypes.ConfigValueInt{Value: 0}
+		testConfig[enableServerCertVerRuleKey] = ctypes.ConfigValueStr{Value: ""}
+		testConfig[keyPathRuleKey] = ctypes.ConfigValueInt{Value: 0}
+		testConfig[passwordRuleKey] = ctypes.ConfigValueInt{Value: 0}
 		testConfig[serverAddrRuleKey] = ctypes.ConfigValueStr{Value: serverAddress}
 		testConfig[sslOptionsRuleKey] = ctypes.ConfigValueBool{Value: sslOptionsFlag}
 		testConfig[usernameRuleKey] = ctypes.ConfigValueInt{Value: 0}
-		testConfig[passwordRuleKey] = ctypes.ConfigValueInt{Value: 0}
-		testConfig[caPathRuleKey] = ctypes.ConfigValueInt{Value: 0}
-		testConfig[certPathRuleKey] = ctypes.ConfigValueInt{Value: 0}
-		testConfig[keyPathRuleKey] = ctypes.ConfigValueInt{Value: 0}
-		testConfig[enableServerCertVerRuleKey] = ctypes.ConfigValueStr{Value: ""}
+		testConfig[tableNameRuleKey] = ctypes.ConfigValueStr{Value: tableName}
+		testConfig[keyspaceName] = ctypes.ConfigValueStr{Value: keyspaceName}
 
 		cfg, errs = configPolicy.Get([]string{""}).Process(testConfig)
 		Convey("So config policy should not return a config after processing testConfig with invalid ssl options", func() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 336023be1e3b912d3f202165b07319d4190e4c59edd016e65355cbc412fe7f22
-updated: 2016-11-16T19:32:00.959436057-08:00
+hash: e3649f79d3a330272250bab0c35dec63d4fde8f9d47063cd00247177d94fc56a
+updated: 2017-04-06T12:00:49.756312993+02:00
 imports:
 - name: github.com/gocql/gocql
-  version: 03ae28ccfc4fa086afea7fcec681bf7ff60f0346
+  version: f8b6dcaf4f8a770652c11e7e94b517fcb706fce8
   subpackages:
   - internal/lru
   - internal/murmur
@@ -47,6 +47,12 @@ imports:
   - convey
   - convey/gotest
   - convey/reporting
+- name: golang.org/x/net
+  version: 04557861f124410b768b1ba5bb3a91b705afbfc6
+  subpackages:
+  - context
+  - http2
+  - trace
 - name: golang.org/x/sys
   version: c8bc69bc2db9c57ccf979550bc69655df5039a8a
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/Sirupsen/logrus
   version: be52937128b38f1d99787bb476c789e2af1147f1
 - package: github.com/gocql/gocql
-  version: 03ae28ccfc4fa086afea7fcec681bf7ff60f0346
+  version: f8b6dcaf4f8a770652c11e7e94b517fcb706fce8
   subpackages:
   - internal/lru
   - internal/murmur


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #

Summary of changes:
- Following configuration flags has been added:
  - `port` - described [here](https://godoc.org/github.com/gocql/gocql#ClusterConfig)
  - `timeout` - described [here](https://godoc.org/github.com/gocql/gocql#ClusterConfig)
  - `connectionTimeout` - described [here](https://godoc.org/github.com/gocql/gocql#ClusterConfig)
  - `initialHostLookup` - described [here](https://godoc.org/github.com/gocql/gocql#ClusterConfig)
  - `ignorePeerAddr`- described [here](https://godoc.org/github.com/gocql/gocql#ClusterConfig)
  - `keyspace` - described [here](https://godoc.org/github.com/gocql/gocql#ClusterConfig)
  - `createKeyspace` - decide that keyspace should be created or not.
- Don't force Keyspace name to `snap`

How to verify it:
- Build and run with external Cassandra instance.

Testing done:
- Tested with production Cassandra

TBD:
- ~~Unit tests~~
- ~~Integration tests~~

A picture of a snapping turtle (not required but encouraged):
![snapping turtle](https://media.giphy.com/media/tj7q6n5L4qW7m/giphy.gif)

Before change:
If your Cassandra cluster is placed in private network with public endpoint and your administrator give you so little permissions(so you cannot even create your own namespace), you cannot use this plugin.

After change:
This PR brings additional options to configure connection to Cassandra cluster. Following options has been added:
- Flexible keyspace and table names
- Ability to decide that keyspace should be created or not(if your admin doesn't bring you permissions to create your own keyspace and you try to create it, your snap task will fail. Now, you can simply skip keyspace creation)
- Ignore discovering nodes in cluster(if your cluster nodes have got private addresses and public keyspace, than you won't connect to particular nodes in cluster with their private addresses)
- Flexible Timeout and first connection Timeout(in case of big latency on your connection, you will need to increase this two parameters)

