### PR TITLE
Primary key on tags table needs to extends PK on metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ CREATE TABLE snap.tags (
     strVal text,   
     boolVal boolean,   
     tags map<text,text>,   
-    PRIMARY KEY ((key, val), time),
+    PRIMARY KEY ((key, val), ns, ver, host, time),
 ) WITH CLUSTERING ORDER BY (time DESC);
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ CREATE TABLE snap.metrics (
     boolVal boolean,
     strVal text,
 	tags map<text,text>, 
-	PRIMARY KEY ((ns, ver, host), time)
+	PRIMARY KEY ((ns, ver, host), time))
 ) WITH CLUSTERING ORDER BY (time DESC);
 ```
 
@@ -92,7 +92,7 @@ CREATE TABLE snap.tags (
     strVal text,   
     boolVal boolean,   
     tags map<text,text>,   
-    PRIMARY KEY ((key, val), ns, ver, host, time),
+    PRIMARY KEY ((key, val), time, ns, ver, host))
 ) WITH CLUSTERING ORDER BY (time DESC);
 ```
 

--- a/cassandra/cassandra.go
+++ b/cassandra/cassandra.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	name       = "cassandra"
-	version    = 6
+	version    = 7
 	pluginType = plugin.PublisherPluginType
 
 	caPathRuleKey              = "caPath"

--- a/cassandra/client.go
+++ b/cassandra/client.go
@@ -37,8 +37,8 @@ var (
 	ErrInvalidDataType = errors.New("Invalid data type value found - %v")
 
 	createKeyspaceCQL = "CREATE KEYSPACE IF NOT EXISTS %s WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1};"
-	createTableCQL    = "CREATE TABLE IF NOT EXISTS %s.%s (ns  text, ver int, host text, time timestamp, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((ns, ver, host), time),) WITH CLUSTERING ORDER BY (time DESC);"
-	createTagTableCQL = "CREATE TABLE IF NOT EXISTS %s.tags (key  text, val text, time timestamp, ns text, ver int, host text, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((key, val), ns, ver, host, time),) WITH CLUSTERING ORDER BY (time DESC);"
+	createTableCQL    = "CREATE TABLE IF NOT EXISTS %s.%s (ns  text, ver int, host text, time timestamp, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((ns, ver, host), time)) WITH CLUSTERING ORDER BY (time DESC);"
+	createTagTableCQL = "CREATE TABLE IF NOT EXISTS %s.tags (key  text, val text, time timestamp, ns text, ver int, host text, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((key, val), time, ns, ver, host)) WITH CLUSTERING ORDER BY (time DESC);"
 	insertMetricsCQL  = `INSERT INTO %s.%s (ns, ver, host, time, valtype, %s, tags) VALUES (?, ?, ?, ? ,?, ?, ?)`
 	insertTagsCQL     = `INSERT INTO %s.tags (key, val, time, ns, ver, host, valtype, %s, tags) VALUES (?, ?, ?, ? ,?, ?, ?, ?, ?)`
 )

--- a/cassandra/client.go
+++ b/cassandra/client.go
@@ -38,7 +38,7 @@ var (
 
 	createKeyspaceCQL = "CREATE KEYSPACE IF NOT EXISTS %s WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1};"
 	createTableCQL    = "CREATE TABLE IF NOT EXISTS %s.%s (ns  text, ver int, host text, time timestamp, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((ns, ver, host), time),) WITH CLUSTERING ORDER BY (time DESC);"
-	createTagTableCQL = "CREATE TABLE IF NOT EXISTS %s.tags (key  text, val text, time timestamp, ns text, ver int, host text, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((key, val), time),) WITH CLUSTERING ORDER BY (time DESC);"
+	createTagTableCQL = "CREATE TABLE IF NOT EXISTS %s.tags (key  text, val text, time timestamp, ns text, ver int, host text, valType text, doubleVal double, strVal text, boolVal boolean, tags map<text,text>, PRIMARY KEY ((key, val), ns, ver, host, time),) WITH CLUSTERING ORDER BY (time DESC);"
 	insertMetricsCQL  = `INSERT INTO %s.%s (ns, ver, host, time, valtype, %s, tags) VALUES (?, ?, ?, ? ,?, ?, ?)`
 	insertTagsCQL     = `INSERT INTO %s.tags (key, val, time, ns, ver, host, valtype, %s, tags) VALUES (?, ?, ?, ? ,?, ?, ?, ?, ?)`
 )

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS snap.tags (
     strVal text,   
     boolVal boolean,   
     tags map<text,text>,   
-    PRIMARY KEY ((key, val), time),
+    PRIMARY KEY ((key, val), ns, ver, host, time),
 ) WITH CLUSTERING ORDER BY (time DESC);
  ```
 

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS snap.metrics (
     strVal text, 
     boolVal boolean, 
     tags map<text,text>, 
-    PRIMARY KEY ((ns, ver, host), time),
+    PRIMARY KEY ((ns, ver, host), time))
 ) WITH CLUSTERING ORDER BY (time DESC);
 ```
 
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS snap.tags (
     strVal text,   
     boolVal boolean,   
     tags map<text,text>,   
-    PRIMARY KEY ((key, val), ns, ver, host, time),
+    PRIMARY KEY ((key, val), time, ns, ver, host))
 ) WITH CLUSTERING ORDER BY (time DESC);
  ```
 


### PR DESCRIPTION
Fixes wrong definition of primary key on table `tags`. Original definition (`PRIMARY KEY ((key, val), time)`) does not allow to insert all the values that are available in `metrics` table. Therefore `tags` primary key needs to be extended.

Summary of changes:
- set `tags` primary key to `PRIMARY KEY ((key, val), ns, ver, host, time)`

How to verify it:
- by attempting to insert to rows with different namespace but same timestamp, key and val to `tags` table.

Testing done:
- none
